### PR TITLE
Added eleventyignore file

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,0 +1,2 @@
+README.md
+macros/**/*.njk


### PR DESCRIPTION
Added [ignore file](https://www.11ty.dev/docs/ignores/) to prevent all files from being processed by Eleventy.
Some files, such as macros and the README presumably should not have its own page.

E.g. currently this [page exists](https://ho-cto.github.io/engineering-guidance-and-standards/README/) and perhaps it shouldn't. The ignore file will stop this being processed.

I've included a line to ignore macros, this directory does not exist at present in main but it is referenced in [another pr](https://github.com/HO-CTO/engineering-guidance-and-standards/pull/90).

