### PR TITLE
Fix for broken tag page links; updated links in tags page to use "url" filter

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -34,3 +34,38 @@ describe('Standards tag page loaded test', () => {
     cy.contains('See all tags')
   })
 })
+
+describe('All tags page loaded test', () => {
+  it('finds the tag page listing all pages with the "standards" tag', () => {
+    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.contains('Learn about standards').click() 
+    cy.contains('Writing a principle').click()
+    cy.get('.app-prose-scope').contains('Standards').click() // this is the "tag" link
+    cy.title().should('include', 'Pages tagged with \"Standards\"')
+    cy.contains('h1', 'Pages tagged with “Standards”') // page renders with “ ” chars
+    cy.contains('See all tags')
+    
+    // Assert all tags link is functional
+    cy.contains('a', 'all tags').click();
+    cy.title().should('include', 'All page tags currently in use')
+    cy.contains('h1', 'All page tags currently in use')
+  })
+})
+
+describe('Writing a principle link from all pages tagged with standards loaded test', () => {
+  it('finds the tag page listing all pages with the "standards" tag', () => {
+    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.contains('Learn about standards').click() 
+    cy.contains('Writing a principle').click()
+    cy.get('.app-prose-scope').contains('Standards').click() // this is the "tag" link
+    cy.title().should('include', 'Pages tagged with \"Standards\"')
+    cy.contains('h1', 'Pages tagged with “Standards”') // page renders with “ ” chars
+    cy.contains('See all tags')
+    
+    // Assert listing page link is functional
+    cy.contains('li a', 'Writing a principle').click()
+    // Assert page has loaded as expected
+    cy.title().should('include', 'Writing a principle')
+    cy.contains('h1', 'Writing a principle');
+  })
+})

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -20,7 +20,7 @@ permalink: /tags/{{ tag }}/
 
 {% set postsWithTag = collections[ tag ] %}
 {% for post in postsWithTag | reverse %}
-- [{{post.data.title}}]({{post.url}})
+- [{{post.data.title}}]({{post.url | url}})
 {% endfor %}
 
-See [all tags](/tags).
+See [all tags]({{"/tags/" | url}})


### PR DESCRIPTION
Updated links in tags page to use "url" filter, ensuring they respect the path prefix
Added cypress tests that check the "all tag" and links from the list of pages using a tag page