### PR TITLE
Create 'work in the open' principle

### DIFF
--- a/docs/principles/collaborative-open-working.md
+++ b/docs/principles/collaborative-open-working.md
@@ -1,0 +1,36 @@
+---
+layout: sub-navigation
+order: 1
+title: Work in the open and be collaborative
+date: git Last Modified
+tags:
+- Ways of working
+- Software Design
+- Collaboration
+---
+
+Last updated: {{ page.date | postDate }}
+Tags: {{ tags | join(', ') }}
+
+Work in the open, providing maximum access and transparency at all times.
+
+---
+
+## Rationale
+
+When working collaboratively this will result in better code and better working practices.
+
+---
+
+## Applications and Implications
+
+- Easily discoverable and approved artefacts.
+- Don't hide technical debt
+- Don't rely on implicit product knowledge
+- Pair programming
+- Discuss often
+- Review others code.
+- Request your code be reviewed.
+- Don't be afraid to question or to be questioned
+
+---

--- a/docs/principles/work-in-the-open.md
+++ b/docs/principles/work-in-the-open.md
@@ -8,7 +8,7 @@ tags:
 - Source management
 ---
 
-{% import "_includes/macros/tags.njk" as pageTag %}
+{% import "macros/tags.njk" as pageTag %}
 
 Last updated: {{ page.date | postDate }}
 {{ pageTag.tags(tags)  }}

--- a/docs/principles/work-in-the-open.md
+++ b/docs/principles/work-in-the-open.md
@@ -1,12 +1,11 @@
 ---
 layout: sub-navigation
 order: 1
-title: Work in the open and be collaborative
+title: Work in the open
 date: git Last Modified
 tags:
 - Ways of working
-- Software Design
-- Collaboration
+- Source management
 ---
 
 Last updated: {{ page.date | postDate }}
@@ -27,10 +26,5 @@ When working collaboratively this will result in better code and better working 
 - Easily discoverable and approved artefacts.
 - Don't hide technical debt
 - Don't rely on implicit product knowledge
-- Pair programming
-- Discuss often
-- Review others code.
-- Request your code be reviewed.
-- Don't be afraid to question or to be questioned
 
 ---

--- a/docs/principles/work-in-the-open.md
+++ b/docs/principles/work-in-the-open.md
@@ -8,23 +8,28 @@ tags:
 - Source management
 ---
 
-Last updated: {{ page.date | postDate }}
-Tags: {{ tags | join(', ') }}
+{% import "_includes/macros/tags.njk" as pageTag %}
 
-Work in the open, providing maximum access and transparency at all times.
+Last updated: {{ page.date | postDate }}
+{{ pageTag.tags(tags)  }}
+
+Work in the open by being transparent and collaborative. Provide maximum access to your work and artefacts, share knowledge and solutions, make collective decisions. Open source your code unless there is a good reason not to.
 
 ---
 
 ## Rationale
 
-When working collaboratively this will result in better code and better working practices.
+The [Home Office DDaT Strategy](https://www.gov.uk/government/publications/home-office-digital-data-and-technology-strategy-2024/home-office-digital-data-and-technology-strategy-2024) advocates working and developing in the open to realise the benefits of shared technology products and to deliver effectively at scale. This is aligned to [point 3 of the Technology Code of Practice](https://www.gov.uk/guidance/be-open-and-use-open-source) and [requirement 12 of the Service Standard](https://www.gov.uk/service-manual/service-standard/point-12-make-new-source-code-open).
+
+Working in the open helps to build institutional memory, shared knowledge and best practice. Sharing code in the open makes it easier for teams to discover patterns and components. This in turn enables reuse and the development of shared technology products, and reduces duplication of effort.
 
 ---
 
 ## Applications and Implications
 
-- Easily discoverable and approved artefacts.
-- Don't hide technical debt
-- Don't rely on implicit product knowledge
+- Make your documentation, artefacts and code easily discoverable for other teams
+- Follow central government and Home Office guidance on open and closed source code
+- Build more secure applications by reducing reliance on 'security by obscurity'
+- Encourage review of work by wider communities, and welcome their feedback and contribution
 
 ---

--- a/docs/principles/work-in-the-open.md
+++ b/docs/principles/work-in-the-open.md
@@ -28,8 +28,8 @@ Working in the open helps to build institutional memory, shared knowledge and be
 ## Applications and Implications
 
 - Make your documentation, artefacts and code easily discoverable for other teams
-- Follow central government and Home Office guidance on open and closed source code
-- Build more secure applications by reducing reliance on 'security by obscurity'
+- Follow [central government guidance on open and closed source code](https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable), bearing in mind Home Office requirements
+- Build more secure applications by reducing reliance on ['security by obscurity'](https://en.wikipedia.org/wiki/Security_through_obscurity)
 - Encourage reviews of work by wider communities, and welcome feedback and contributions
 
 ---

--- a/docs/principles/work-in-the-open.md
+++ b/docs/principles/work-in-the-open.md
@@ -30,6 +30,6 @@ Working in the open helps to build institutional memory, shared knowledge and be
 - Make your documentation, artefacts and code easily discoverable for other teams
 - Follow central government and Home Office guidance on open and closed source code
 - Build more secure applications by reducing reliance on 'security by obscurity'
-- Encourage review of work by wider communities, and welcome their feedback and contribution
+- Encourage reviews of work by wider communities, and welcome feedback and contributions
 
 ---


### PR DESCRIPTION
Content migration from internal docs with rewrite to bring in line with 'writing a principle' standard, and flesh out main sections.

This will close #97 