### PR TITLE
Feedback banner contained within aside landmark element

### DIFF
--- a/_includes/macros/feedbackBanner.njk
+++ b/_includes/macros/feedbackBanner.njk
@@ -3,6 +3,8 @@
 {# Components #}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
-{{ govukPhaseBanner(configuration) }}
+<aside>
+  {{ govukPhaseBanner(configuration) }}
+</aside>
 
 {% endmacro %}


### PR DESCRIPTION
I chose to use the [aside](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside) element as a landmark container for the feedback phase banner as I considered it to fall under the below definition:

> portion of a document whose content is only indirectly related to the document's main content.

I had considered using the [banner role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_Role), however I don't think this is appropriate (despite the component being named phase *banner*). In addition, we have a banner role (the top bar) and you [cannot have two banner roles](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/banner.html).

> Each page may have one banner landmark.