### PR TITLE
Added link to GitHub repository in footer

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -31,6 +31,12 @@ module.exports = function(eleventyConfig) {
             copyright: {
                 html: '© <a class="govuk-footer__link" href="https://github.com/HO-CTO/engineering-guidance-and-standards/blob/main/LICENCE">Crown Copyright (Home Office)</a>'
             },
+            meta: {
+                items: [{
+                    href: 'https://github.com/HO-CTO/engineering-guidance-and-standards',
+                    text: 'GitHub repository'
+                }]
+            }
         },
         stylesheets: ['/styles/base.css'],
     })


### PR DESCRIPTION
I have used ["Footer with links"](https://design-system.service.gov.uk/components/footer/) for the addition of the GitHub repo link.

Please see below for preview of updated UI.

![image](https://github.com/HO-CTO/engineering-guidance-and-standards/assets/133027753/a9451362-5f15-48ac-b351-02a2a5c43c09)
