### PR TITLE
Excluded about page from eleventy collections

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,4 +1,5 @@
 ---
+eleventyExcludeFromCollections: true
 layout: page
 order: 5
 title: About


### PR DESCRIPTION
Removing about link from eleventy collections, which prevents the page appearing in the sidebar on pages that use the sub-navigation layout

# Code change
I can confirm:
## Accessibility considerations
- [x] This change will not change layouts, page structures or anything else that might impact accessibility

or
- [ ] This change might impact accessibility, automated aXe tests cover the impact

or
- [ ] This change might impact accessibility and is not covered by automated aXe tests - manual testing has been performed
(If the change might impact accessibility then please add some further information here)

