### PR TITLE
Fixed link in related link section for standards page

### DIFF
--- a/docs/standards.md
+++ b/docs/standards.md
@@ -13,5 +13,5 @@ related:
     - title: Related links
       items:
         - text: Writing a standard
-          href: /standards/writing-a-standard
+          href: writing-a-standard
 ---


### PR DESCRIPTION
Corrected link.

Please note: the link is relative from the standards page, so this will need considering when adding other related links from other pages.

# Code change
I can confirm:
## Accessibility considerations
- [x] This change will not change layouts, page structures or anything else that might impact accessibility