### PR TITLE
Fix for #209 - support path prefix in related links

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -70,7 +70,7 @@ module.exports = function(eleventyConfig) {
     });
 
     eleventyConfig.addCollection("homepageLinks", function(collectionApi) {
-      return collectionApi.getFilteredByGlob([ 
+      return collectionApi.getFilteredByGlob([
         "**/patterns.md",
         "**/principles.md",
         "**/standards.md"]);
@@ -108,6 +108,8 @@ module.exports = function(eleventyConfig) {
         html: 'This is a new service – your <a class="govuk-link" target="_blank" href="https://www.homeofficesurveys.homeoffice.gov.uk/s/8PDDG2/">feedback (opens in a new tab)</a> will help us to improve it.'
       }
     });
+
+    eleventyConfig.addGlobalData('pathPrefix', _customPathPrefix);
 
     return {
         dataTemplateEngine: 'njk',

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -32,6 +32,7 @@ jobs:
           wait-on: 'http://${{ env.TEST_URL }}:${{ env.TEST_PORT }}${{ env.TEST_PATH_PREFIX }}'
           config: 'video=false,screenshotOnRunFailure=false'
         env:
-          CYPRESS_TEST_URL: ${{ env.TEST_URL }}${{ env.TEST_PATH_PREFIX }}
+          CYPRESS_TEST_URL: ${{ env.TEST_URL }}
           CYPRESS_TEST_PORT: ${{ env.TEST_PORT }}
+          CYPRESS_TEST_PATH_PREFIX: ${{ env.TEST_PATH_PREFIX }}
           PATH_PREFIX: ${{ env.TEST_PATH_PREFIX }}

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -9,6 +9,7 @@ on:
 env:
   TEST_URL: localhost
   TEST_PORT: 8080
+  TEST_PATH_PREFIX: '/test/'
 
 jobs:
   e2e-test:
@@ -28,8 +29,9 @@ jobs:
           browser: chrome
           build: npm run build
           start: npm run serve -- --port ${{ env.TEST_PORT }}
-          wait-on: 'http://${{ env.TEST_URL }}:${{ env.TEST_PORT }}'
+          wait-on: 'http://${{ env.TEST_URL }}:${{ env.TEST_PORT }}${{ env.TEST_PATH_PREFIX }}'
           config: 'video=false,screenshotOnRunFailure=false'
         env:
-          CYPRESS_TEST_URL: ${{ env.TEST_URL }}
+          CYPRESS_TEST_URL: ${{ env.TEST_URL }}${{ env.TEST_PATH_PREFIX }}
           CYPRESS_TEST_PORT: ${{ env.TEST_PORT }}
+          PATH_PREFIX: ${{TEST_PATH_PREFIX}}

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           CYPRESS_TEST_URL: ${{ env.TEST_URL }}${{ env.TEST_PATH_PREFIX }}
           CYPRESS_TEST_PORT: ${{ env.TEST_PORT }}
-          PATH_PREFIX: ${{TEST_PATH_PREFIX}}
+          PATH_PREFIX: ${{ env.TEST_PATH_PREFIX }}

--- a/_data/eleventyComputed.js
+++ b/_data/eleventyComputed.js
@@ -1,8 +1,33 @@
 // noinspection JSUnusedGlobalSymbols
 
+function mapRelatedSections(sections, pathPrefix) {
+  return sections.map(
+    section => ({
+      ...section,
+      items: (section.items ?? []).map(item => ({
+        ...item,
+        href: item.href?.startsWith('/') && pathPrefix ? `${pathPrefix}${item.href}` : item.href,
+      })),
+      subsections: mapRelatedSections(section.subsections ?? [], pathPrefix),
+    })
+  );
+}
+
 module.exports = {
   eleventyExcludeFromCollections: ({page, eleventyExcludeFromCollections}) => {
     return eleventyExcludeFromCollections || page.templateSyntax === 'scss';
+  },
+  // the path prefix isn't applied to related link urls by xGovukRelatedNavigation - so map them here
+  related: ({related, pathPrefix}) => {
+    console.log({related, pathPrefix})
+
+    if (!related) {
+      return related;
+    }
+
+    related.sections = mapRelatedSections(related.sections ?? [related], pathPrefix);
+
+    return related;
   }
 }
 

--- a/_data/eleventyComputed.js
+++ b/_data/eleventyComputed.js
@@ -1,4 +1,5 @@
 // noinspection JSUnusedGlobalSymbols
+const { applyBaseToUrl } = require('@11ty/eleventy/src/Plugins/HtmlBasePlugin')
 
 function mapRelatedSections(sections, pathPrefix) {
   return sections.map(
@@ -6,7 +7,7 @@ function mapRelatedSections(sections, pathPrefix) {
       ...section,
       items: (section.items ?? []).map(item => ({
         ...item,
-        href: item.href?.startsWith('/') && pathPrefix ? `${pathPrefix}${item.href}` : item.href,
+        href: applyBaseToUrl(item.href, pathPrefix, {pathPrefix}),
       })),
       subsections: mapRelatedSections(section.subsections ?? [], pathPrefix),
     })
@@ -19,8 +20,6 @@ module.exports = {
   },
   // the path prefix isn't applied to related link urls by xGovukRelatedNavigation - so map them here
   related: ({related, pathPrefix}) => {
-    console.log({related, pathPrefix})
-
     if (!related) {
       return related;
     }

--- a/cypress/e2e/a11y.spec.cy.js
+++ b/cypress/e2e/a11y.spec.cy.js
@@ -27,7 +27,7 @@ function terminalLog(violations) {
 describe('All pages pass axe-core accessibility checks', () => {
   for(const page of pages) {
     it(`${page.title} (${page.url}) is accessible`, () => {
-      cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT + page.url)
+      cy.visit(testing_params.TEST_ROOT_URL + page.url)
       cy.injectAxe()
       cy.checkA11y({exclude: '[data-axe-exclude]'}, null, terminalLog);
     })

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -2,7 +2,7 @@ import {testing_params} from "../support/testing_params";
 
 describe('Front page loaded test', () => {
   it('finds the front page describing the sections of the site', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     cy.contains('h1', 'Engineering Guidance and Standards')
     cy.contains('Principles')
     cy.contains('Standards')
@@ -12,7 +12,7 @@ describe('Front page loaded test', () => {
 
 describe('Standards page loaded test', () => {
   it('finds the page listing all standards', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     cy.contains('Read our standards').click()
     cy.title().should('include', 'Standards')
     cy.contains('.x-govuk-masthead h1', 'Standards')
@@ -22,7 +22,7 @@ describe('Standards page loaded test', () => {
 
 describe('Principles page loaded test', () => {
   it('finds the page listing all principles', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     cy.contains('Read our principles').click()
     cy.contains('.x-govuk-masthead h1', 'Principles')
     cy.contains('.x-govuk-masthead', 'To guide the behaviour and decisions of engineering teams')
@@ -31,13 +31,13 @@ describe('Principles page loaded test', () => {
 
 describe('Tag page loaded test', () => {
   it('finds the tag page listing all pages with the "Documentation" tag', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     cy.contains('Read our standards').click()
     cy.contains('Minimal documentation set for a product').click()
     cy.get('.tags').contains('Documentation').click() // this is the "tag" link
     cy.title().should('include', 'Pages tagged with \"Documentation\"')
     cy.contains('h1', 'Pages tagged with “Documentation”') // page renders with “ ” chars
-    
+
     cy.contains('li', 'Write effective documentation')
     cy.contains('li', 'Minimal documentation set for a product')
   })
@@ -45,7 +45,7 @@ describe('Tag page loaded test', () => {
 
 describe('Standards page loaded test when clicked from tag', () => {
   it('finds the tag link for standards and checks we go to the Standards collection page', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     cy.contains('Read our standards').click()
     cy.contains('Minimal documentation set for a product').click()
     cy.get('.tags').contains('Standards').click() // this is the "tag" link
@@ -57,7 +57,7 @@ describe('Standards page loaded test when clicked from tag', () => {
 
 describe('All tags page loaded test', () => {
   it('finds the tag page listing all pages with the "standards" tag', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     cy.contains('Read our standards').click()
     cy.contains('Minimal documentation set for a product').click()
     cy.get('.tags').contains('Documentation').click() // this is the "tag" link
@@ -74,7 +74,7 @@ describe('All tags page loaded test', () => {
 
 describe('Sidebar link to other standards loaded test', () => {
   it('finds a sidebar link to another standard when viewing a standard', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     cy.contains('Read our standards').click()
     cy.contains('Minimal documentation set for a product').click()
     // reach the first standard page
@@ -89,7 +89,7 @@ describe('Sidebar link to other standards loaded test', () => {
 
 describe('About page links from index page start button test', () => {
   it('finds the about page describing the aims of the site', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     // Click on first el containing the about page text
     cy.contains('Find out more about what we are doing').click()
     cy.contains('h2', 'Why we are doing it')
@@ -98,7 +98,7 @@ describe('About page links from index page start button test', () => {
 
 describe('About page links from footer test', () => {
   it('finds the about page describing the aims of the site', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     // Click on first li a containing 'About' page text
     cy.contains('li a', 'About').click()
     cy.contains('h2', 'Why we are doing it')
@@ -107,9 +107,20 @@ describe('About page links from footer test', () => {
 
 describe('Cookies page links from footer test', () => {
   it('finds the cookies page giving a summary of cookie usage on the site', () => {
-    cy.visit(testing_params.TEST_URL + ":" + testing_params.TEST_PORT)
+    cy.visit(testing_params.TEST_ROOT_URL)
     // Click on first li a containing 'About' page text
     cy.contains('li a', 'Cookies').click()
     cy.contains('h1', 'How we use cookies')
+  })
+})
+
+describe('Related links respect path prefix', () => {
+  it('finds the related writing a standard link and follows it to a valid page', () => {
+    cy.visit(testing_params.TEST_ROOT_URL)
+    // Click to standards page that has a related link
+    cy.contains('Read our standards').click()
+    // Use the related link
+    cy.contains('.x-govuk-related-navigation a', 'Writing a standard').click()
+    cy.contains('h1', 'Writing a standard')
   })
 })

--- a/cypress/support/testing_params.js
+++ b/cypress/support/testing_params.js
@@ -1,4 +1,10 @@
+const TEST_URL = Cypress.env('TEST_URL') ?? 'http://localhost';
+const TEST_PORT = Cypress.env('TEST_PORT') ?? '8080';
+const TEST_PATH = Cypress.env('TEST_PATH') ?? '';
+
 export const testing_params = {
-  TEST_URL: Cypress.env('TEST_URL') ?? 'http://localhost',
-  TEST_PORT: Cypress.env('TEST_PORT') ?? '8080'
+  TEST_URL: TEST_URL,
+  TEST_PORT: TEST_PORT,
+  TEST_PATH: TEST_PATH,
+  TEST_ROOT_URL: `${TEST_URL}:${TEST_PORT}${TEST_PATH.replace(/\/$/, '')}`
 }

--- a/docs/patterns/pattern.template.md
+++ b/docs/patterns/pattern.template.md
@@ -11,21 +11,21 @@ related: # remove this section if you do not need related links on your page
     - title: Related links
       items:
         - text: Writing a standard
-          href: /standards/writing-a-standard # Note: use an absolute link from the site home page
+          href: /standards/writing-a-standard/ # Note: use an absolute link from the site home page
 ---
 
 <!-- Pattern description -->
 
-### Using links
-#### Internal links
-Internal links need to follow this format:
-[link text to internal page]({{ '/standards/writing-a-standard' | url }})
+<!-- 
+# Notes on using links
 
+Internal links need to follow this format:
+[link text to internal page]({{ '/standards/writing-a-standard/' | url }})
 Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
 
-#### External links
 External links follow standard markdown formatting:
 [link text to external page](https://example.com)
+-->
 
 ---
 

--- a/docs/patterns/pattern.template.md
+++ b/docs/patterns/pattern.template.md
@@ -3,12 +3,29 @@ layout: pattern
 order: 1
 title: Pattern title
 date: git Last Modified
-tags: <!-- use tags: [] for no tags, note "Pattern" tag included automatically -->
+tags: # use `tags: []` for no tags, "Patterns" tag is included automatically
   - TAG 1
   - TAG 2
+related: # remove this section if you do not need related links on your page
+  sections:
+    - title: Related links
+      items:
+        - text: Writing a standard
+          href: /standards/writing-a-standard # Note: use an absolute link from the site home page
 ---
 
 <!-- Pattern description -->
+
+### Using links
+#### Internal links
+Internal links need to follow this format:
+[link text to internal page]({{ '/standards/writing-a-standard' | url }})
+
+Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
+
+#### External links
+External links follow standard markdown formatting:
+[link text to external page](https://example.com)
 
 ---
 

--- a/docs/principles/principle.template.md
+++ b/docs/principles/principle.template.md
@@ -3,12 +3,29 @@ layout: principle
 order: 1
 title: Principle title
 date: git Last Modified
-tags: <!-- use tags: [] for no tags, note "Principles" tag included automatically -->
+tags: # use `tags: []` for no tags, "Principles" tag is included automatically
   - TAG 1
   - TAG 2
+related: # remove this section if you do not need related links on your page
+  sections:
+    - title: Related links
+      items:
+        - text: Writing a standard
+          href: /standards/writing-a-standard # Note: use an absolute link from the site home page
 ---
 
 <!-- Principle description -->
+
+### Using links
+#### Internal links
+Internal links need to follow this format:
+[link text to internal page]({{ '/standards/writing-a-standard' | url }})
+
+Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
+
+#### External links
+External links follow standard markdown formatting:
+[link text to external page](https://example.com)
 
 ---
 

--- a/docs/principles/principle.template.md
+++ b/docs/principles/principle.template.md
@@ -11,21 +11,21 @@ related: # remove this section if you do not need related links on your page
     - title: Related links
       items:
         - text: Writing a standard
-          href: /standards/writing-a-standard # Note: use an absolute link from the site home page
+          href: /standards/writing-a-standard/ # Note: use an absolute link from the site home page
 ---
 
 <!-- Principle description -->
 
-### Using links
-#### Internal links
-Internal links need to follow this format:
-[link text to internal page]({{ '/standards/writing-a-standard' | url }})
+<!-- 
+# Notes on using links
 
+Internal links need to follow this format:
+[link text to internal page]({{ '/standards/writing-a-standard/' | url }})
 Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
 
-#### External links
 External links follow standard markdown formatting:
 [link text to external page](https://example.com)
+-->
 
 ---
 

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -13,5 +13,5 @@ related:
     - title: Related links
       items:
         - text: Writing a standard
-          href: /standards/writing-a-standard
+          href: /standards/writing-a-standard/ # https://github.com/11ty/eleventy-dev-server/pull/64
 ---

--- a/docs/standards/standard.template.md
+++ b/docs/standards/standard.template.md
@@ -3,13 +3,30 @@ layout: standard
 order: 1
 title: Standard title
 date: git Last Modified
-id: SEGAS-00000 <!-- Set unique ID for standard -->
-tags: <!-- use tags: [] for no tags, note "Standards" tag included automatically -->
+id: SEGAS-00000 # Set unique ID for standard
+tags: # use `tags: []` for no tags, "Standards" tag is included automatically
   - TAG 1
   - TAG 2
+related: # remove this section if you do not need related links on your page
+  sections:
+    - title: Related links
+      items:
+        - text: Writing a standard
+          href: /standards/writing-a-standard # Note: use an absolute link from the site home page
 ---
 
 <!-- Standard description -->
+
+### Using links
+#### Internal links
+Internal links need to follow this format:
+[link text to internal page]({{ '/standards/writing-a-standard' | url }})
+
+Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
+
+#### External links
+External links follow standard markdown formatting:
+[link text to external page](https://example.com)
 
 ---
 

--- a/docs/standards/standard.template.md
+++ b/docs/standards/standard.template.md
@@ -12,21 +12,21 @@ related: # remove this section if you do not need related links on your page
     - title: Related links
       items:
         - text: Writing a standard
-          href: /standards/writing-a-standard # Note: use an absolute link from the site home page
+          href: /standards/writing-a-standard/ # Note: use an absolute link from the site home page
 ---
 
 <!-- Standard description -->
 
-### Using links
-#### Internal links
-Internal links need to follow this format:
-[link text to internal page]({{ '/standards/writing-a-standard' | url }})
+<!-- 
+# Notes on using links
 
+Internal links need to follow this format:
+[link text to internal page]({{ '/standards/writing-a-standard/' | url }})
 Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
 
-#### External links
 External links follow standard markdown formatting:
 [link text to external page](https://example.com)
+-->
 
 ---
 


### PR DESCRIPTION
Replaces or compliments #210 - adds mapping for related links frontmatter to include pathPrefix so that absolute links work.

Updates Cypress tests to support a path prefix so that this can be tested in the GitHub action test run.

# Code change
I can confirm:
## Accessibility considerations
- [x] This change might impact accessibility, automated aXe tests cover the impact
