### PR TITLE
Updated last updated dates for content pages - removed usage of git Last Modified

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,4 @@ e.g. [Writing a principle](https://ho-cto.github.io/engineering-guidance-and-sta
     - Content does not relate to unreleased gov policy
     - Content does not refer to anti-fraud mechanisms
     - Content does not include sensitive business logic
-- [ ] Last updated date(s) in content page(s) front-matter has been updated
+- [ ] Last updated date for content is correct

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,4 @@ e.g. [Writing a principle](https://ho-cto.github.io/engineering-guidance-and-sta
     - Content does not relate to unreleased gov policy
     - Content does not refer to anti-fraud mechanisms
     - Content does not include sensitive business logic
+- [ ] Last updated date(s) in content page(s) front-matter has been updated

--- a/docs/patterns/docs-as-code.md
+++ b/docs/patterns/docs-as-code.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Docs as code
-date: git Last Modified
+date: 2023-08-03
 tags:
 - Ways of working
 - Source management

--- a/docs/patterns/immutable-artefacts.md
+++ b/docs/patterns/immutable-artefacts.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Immutable artefacts
-date: git Last Modified
+date: 2023-08-03
 tags:
 - Build, release and deploy
 - Deployment

--- a/docs/patterns/monitoring-as-code.md
+++ b/docs/patterns/monitoring-as-code.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Monitoring-as-code (MaC)
-date: git Last Modified
+date: 2023-05-31
 tags:
 - Observability
 - Monitoring

--- a/docs/patterns/pattern.template.md
+++ b/docs/patterns/pattern.template.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Pattern title
-date: git Last Modified
+date: 2023-12-31 # use last updated date
 tags: # use `tags: []` for no tags, "Patterns" tag is included automatically
   - TAG 1
   - TAG 2

--- a/docs/patterns/pattern.template.md
+++ b/docs/patterns/pattern.template.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Pattern title
-date: 2023-12-31 # use last updated date
+date: 2023-12-31 # this should be the date that the content was most recently amended or formally reviewed
 tags: # use `tags: []` for no tags, "Patterns" tag is included automatically
   - TAG 1
   - TAG 2

--- a/docs/patterns/pattern.template.md
+++ b/docs/patterns/pattern.template.md
@@ -3,7 +3,10 @@ layout: pattern
 order: 1
 title: Pattern title
 date: 2023-12-31 # this should be the date that the content was most recently amended or formally reviewed
-tags: # use `tags: []` for no tags, "Patterns" tag is included automatically
+# use `tags: []` for no tags, "Patterns" tag is included automatically 
+# Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
+# Note: tags must match capitalisation of previously used tags
+tags:
   - TAG 1
   - TAG 2
 related: # remove this section if you do not need related links on your page

--- a/docs/patterns/pattern.template.md
+++ b/docs/patterns/pattern.template.md
@@ -5,10 +5,10 @@ title: Pattern title
 date: 2023-12-31 # this should be the date that the content was most recently amended or formally reviewed
 # use `tags: []` for no tags, "Patterns" tag is included automatically 
 # Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
-# Note: tags must match capitalisation of previously used tags
+# Note: tags must use sentence case capitalisation
 tags:
-  - TAG 1
-  - TAG 2
+  - Tag one
+  - Tag two
 related: # remove this section if you do not need related links on your page
   sections:
     - title: Related links

--- a/docs/patterns/selecting-a-deployment-strategy.md
+++ b/docs/patterns/selecting-a-deployment-strategy.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Selecting a deployment strategy
-date: git Last Modified
+date: 2023-07-25
 tags:
 - Build, release and deploy
 - Deployment

--- a/docs/patterns/write-effective-documentation.md
+++ b/docs/patterns/write-effective-documentation.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Write effective documentation
-date: git Last Modified
+date: 2023-07-18
 tags:
 - Ways of working
 - Documentation

--- a/docs/principles/be-collaborative.md
+++ b/docs/principles/be-collaborative.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Be collaborative
-date: git Last Modified
+date: 2023-06-22
 tags:
 - Software design
 - Ways of working

--- a/docs/principles/design-for-success.md
+++ b/docs/principles/design-for-success.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Design for success
-date: git Last Modified
+date: 2023-06-09
 tags:
   - Software design
 ---

--- a/docs/principles/monitor-and-measure.md
+++ b/docs/principles/monitor-and-measure.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Monitor and measure proactively
-date: git Last Modified
+date: 2023-07-28
 tags:
 - Ways of working
 - Build, release and deploy

--- a/docs/principles/principle.template.md
+++ b/docs/principles/principle.template.md
@@ -3,7 +3,10 @@ layout: principle
 order: 1
 title: Principle title
 date: 2023-12-31 # this should be the date that the content was most recently amended or formally reviewed
-tags: # use `tags: []` for no tags, "Principles" tag is included automatically
+# use `tags: []` for no tags, "Principles" tag is included automatically 
+# Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
+# Note: tags must match capitalisation of previously used tags
+tags:
   - TAG 1
   - TAG 2
 related: # remove this section if you do not need related links on your page

--- a/docs/principles/principle.template.md
+++ b/docs/principles/principle.template.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Principle title
-date: 2023-12-31 # use last updated date
+date: 2023-12-31 # this should be the date that the content was most recently amended or formally reviewed
 tags: # use `tags: []` for no tags, "Principles" tag is included automatically
   - TAG 1
   - TAG 2

--- a/docs/principles/principle.template.md
+++ b/docs/principles/principle.template.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Principle title
-date: git Last Modified
+date: 2023-12-31 # use last updated date
 tags: # use `tags: []` for no tags, "Principles" tag is included automatically
   - TAG 1
   - TAG 2

--- a/docs/principles/principle.template.md
+++ b/docs/principles/principle.template.md
@@ -5,10 +5,10 @@ title: Principle title
 date: 2023-12-31 # this should be the date that the content was most recently amended or formally reviewed
 # use `tags: []` for no tags, "Principles" tag is included automatically 
 # Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
-# Note: tags must match capitalisation of previously used tags
+# Note: tags must use sentence case capitalisation
 tags:
-  - TAG 1
-  - TAG 2
+  - Tag one
+  - Tag two
 related: # remove this section if you do not need related links on your page
   sections:
     - title: Related links

--- a/docs/principles/proportionate-security.md
+++ b/docs/principles/proportionate-security.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 4
 title: Proportionate security
-date: git Last Modified
+date: 2023-07-13
 tags:
 - Security
 - Software design

--- a/docs/principles/provide-good-engineering-experience.md
+++ b/docs/principles/provide-good-engineering-experience.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Provide a good engineering experience
-date: git Last Modified
+date: 2023-07-26
 tags:
 - Ways of working
 ---

--- a/docs/principles/security-is-everyones-responsibility.md
+++ b/docs/principles/security-is-everyones-responsibility.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 5
 title: Security is everyone's responsibility
-date: git Last Modified
+date: 2023-07-13
 tags:
 - Security
 - Ways of working

--- a/docs/principles/well-managed-code.md
+++ b/docs/principles/well-managed-code.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Well managed code
-date: git Last Modified
+date: 2023-07-14
 tags:
 - Source management
 - Ways of working

--- a/docs/principles/work-in-the-open.md
+++ b/docs/principles/work-in-the-open.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Work in the open
-date: git Last Modified
+date: 2023-07-13
 tags:
 - Ways of working
 - Source management

--- a/docs/principles/write-maintainable-reusable-and-evolutionary-code.md
+++ b/docs/principles/write-maintainable-reusable-and-evolutionary-code.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: Write maintainable, reusable and evolutionary code
-date: git Last Modified
+date: 2023-07-25
 tags:
   - Ways of working
   - Software design

--- a/docs/principles/zero-trust.md
+++ b/docs/principles/zero-trust.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 3
 title: Zero trust
-date: git Last Modified
+date: 2023-07-13
 tags:
 - Security
 - Software design

--- a/docs/standards/infrastructure-as-code.md
+++ b/docs/standards/infrastructure-as-code.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Infrastructure as code
-date: git Last Modified
+date: 2023-08-03
 id: SEGAS-00005
 tags:
 - Source management

--- a/docs/standards/minimal-documentation-set-for-a-product.md
+++ b/docs/standards/minimal-documentation-set-for-a-product.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Minimal documentation set for a product
-date: git Last Modified
+date: 2023-06-13
 id: SEGAS-00003
 tags:
 - Documentation

--- a/docs/standards/open-source-licensing.md
+++ b/docs/standards/open-source-licensing.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Open source licensing
-date: git Last Modified
+date: 2023-05-24
 id: SEGAS-00004
 tags:
 - Source management

--- a/docs/standards/standard.template.md
+++ b/docs/standards/standard.template.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Standard title
-date: git Last Modified
+date: 2023-12-31 # use last updated date
 id: SEGAS-00000 # Set unique ID for standard
 tags: # use `tags: []` for no tags, "Standards" tag is included automatically
   - TAG 1

--- a/docs/standards/standard.template.md
+++ b/docs/standards/standard.template.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Standard title
-date: 2023-12-31 # use last updated date
+date: 2023-12-31 # this should be the date that the content was most recently amended or formally reviewed
 id: SEGAS-00000 # Set unique ID for standard
 tags: # use `tags: []` for no tags, "Standards" tag is included automatically
   - TAG 1

--- a/docs/standards/standard.template.md
+++ b/docs/standards/standard.template.md
@@ -4,7 +4,10 @@ order: 1
 title: Standard title
 date: 2023-12-31 # this should be the date that the content was most recently amended or formally reviewed
 id: SEGAS-00000 # Set unique ID for standard
-tags: # use `tags: []` for no tags, "Standards" tag is included automatically
+# use `tags: []` for no tags, "Standards" tag is included automatically. 
+# Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
+# Note: tags must match capitalisation of previously used tags
+tags: 
   - TAG 1
   - TAG 2
 related: # remove this section if you do not need related links on your page

--- a/docs/standards/standard.template.md
+++ b/docs/standards/standard.template.md
@@ -6,10 +6,10 @@ date: 2023-12-31 # this should be the date that the content was most recently am
 id: SEGAS-00000 # Set unique ID for standard
 # use `tags: []` for no tags, "Standards" tag is included automatically. 
 # Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
-# Note: tags must match capitalisation of previously used tags
-tags: 
-  - TAG 1
-  - TAG 2
+# Note: tags must use sentence case capitalisation
+tags:
+  - Tag one
+  - Tag two
 related: # remove this section if you do not need related links on your page
   sections:
     - title: Related links

--- a/docs/standards/writing-a-principle.md
+++ b/docs/standards/writing-a-principle.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Writing a principle
-date: git Last Modified
+date: 2023-08-04
 id: SEGAS-00002
 tags: []
 ---
@@ -91,12 +91,11 @@ tags:
 
 ### A principle MUST show when it was last updated
 
-Show the date the principle was last updated. This will automatically be 
-generated from the git commit time and shown at the top of the page.  The 
-metadata needs to be set as the following.
+Show the date the principle was last updated. The 
+metadata needs to include the date in YYYY-MM-DD format (see below).
 
 ```
-date: git Last Modified
+date: 2023-12-31
 ```
 ---
 

--- a/docs/standards/writing-a-standard.md
+++ b/docs/standards/writing-a-standard.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Writing a standard
-date: git Last Modified
+date: 2023-08-04
 id: SEGAS-00001
 tags: []
 ---
@@ -95,11 +95,11 @@ tags:
 ### A standard MUST show when it was last updated
 
 Products and services are built to a standard and as time goes by standards
-evolve. This will automatically be generated from the git commit time and
-shown at the top of the page.  The metadata needs to be set as the following.
+evolve. Show the date the standard was last updated. 
+The metadata needs to include the date in YYYY-MM-DD format (see below).
 
 ```
-date: git Last Modified
+date: 2023-12-31
 ```
 ---
 

--- a/docs/standards/writing-a-standard.md
+++ b/docs/standards/writing-a-standard.md
@@ -106,4 +106,5 @@ date: 2023-12-31
 ## Template
 
 You can use the [standard template](https://github.com/HO-CTO/engineering-guidance-and-standards/blob/main/docs/standards/standard.template.md) when creating a new standard.
+
 ---


### PR DESCRIPTION
- Updated all content pages to use the explicit last updated date rather than `git Last Modified`
- Updated writing a principle/standard to reflect changes on usage of last updated date
- Added step for PR template to confirm last updated dates are updated

Is this pull request a content or a code change? (Please fill in the relevant section and delete the other)

# Code change
I can confirm:
## Accessibility considerations
- [x] This change will not change layouts, page structures or anything else that might impact accessibility

# Content change 
I can confirm:
- [x] Content does not include any code or configuration changes (excluding frontmatter information)
- [x] Content meets the content standards
e.g. [Writing a principle](https://ho-cto.github.io/engineering-guidance-and-standards/docs/standards/writing-a-principle/) and [Writing a standard](https://ho-cto.github.io/engineering-guidance-and-standards/docs/standards/writing-a-standard/)
- [x] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [x] Last updated date for content is correct
