### PR TITLE
Use govuk summary list for docs-as-code technology options

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,7 +7,7 @@ module.exports = function(eleventyConfig) {
     // Pass assets through to final build directory
     eleventyConfig.addPassthroughCopy({ "docs/assets/logos": "assets/logos"});
     // Register the plugins
-    eleventyConfig.addPlugin(govukEleventyPlugin, {
+    let govukPluginOptions = {
         brandColour: '#8f23b3',
         fontFamily: 'roboto, system-ui, sans-serif',
         icons: {
@@ -18,7 +18,7 @@ module.exports = function(eleventyConfig) {
         opengraphImageUrl: '/assets/logos/ho-opengraph-image.png',
         homeKey: 'Home',
         header: {
-            organisationLogo: '<img src="'+_customPathPrefix+'/assets/logos/ho_logo.svg" height="34px" alt="Home Office Logo">',
+            organisationLogo: '<img src="' + _customPathPrefix + '/assets/logos/ho_logo.svg" height="34px" alt="Home Office Logo">',
             organisationName: 'Home Office',
             productName: 'Engineering Guidance and Standards',
             search: {
@@ -33,22 +33,33 @@ module.exports = function(eleventyConfig) {
             },
             meta: {
                 items: [
-                {
-                    href: _customPathPrefix+'/about/',
-                    text: 'About'
-                },
-                {
-                    href: _customPathPrefix+'/cookies/',
-                    text: 'Cookies'
-                },
-                {
-                    href: 'https://github.com/HO-CTO/engineering-guidance-and-standards',
-                    text: 'GitHub repository'
-                }
-              ]
+                    {
+                        href: _customPathPrefix + '/about/',
+                        text: 'About'
+                    },
+                    {
+                        href: _customPathPrefix + '/cookies/',
+                        text: 'Cookies'
+                    },
+                    {
+                        href: 'https://github.com/HO-CTO/engineering-guidance-and-standards',
+                        text: 'GitHub repository'
+                    }
+                ]
             }
         },
         stylesheets: ['/styles/base.css'],
+    };
+    eleventyConfig.addPlugin(govukEleventyPlugin, govukPluginOptions)
+
+    // Customise markdown-it renderer provided by x-gov 11ty plugin. Plugin execution is
+    // deferred, so this needs to be a plugin, and added after the x-gov plugin is.
+    eleventyConfig.addPlugin((eleventyConfig) => {
+        const md = require('@x-govuk/govuk-eleventy-plugin/lib/markdown-it.js')(govukPluginOptions)
+
+        md.use(require('./lib/markdown/dl-as-govuk-summary-list'));
+
+        eleventyConfig.setLibrary('md', md);
     })
 
     eleventyConfig.addFilter("postDate", (dateObj) => {

--- a/docs/patterns/docs-as-code.md
+++ b/docs/patterns/docs-as-code.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Docs as code
-date: 2023-08-03
+date: 2023-08-11
 tags:
 - Ways of working
 - Source management

--- a/docs/patterns/docs-as-code.md
+++ b/docs/patterns/docs-as-code.md
@@ -47,11 +47,38 @@ A docs as code approach also gives you the following benefits:
 
 The Home Office software engineering Ways of Working guild has investigated some different technical products for implementing docs as code approaches. An outline of options is below, this site uses the x-gov Eleventy plugin.
 
-#### Technical Options
+#### Middleman and GDS Tech Docs Template
 
-| Option and links to documentation | Reviewed | Comments | Examples of HO documentation using this option |
-|---|---|---|---|
-| Middle man and GDS Tech Docs Template <br><br> https://middlemanapp.com/ <br><br> https://github.com/alphagov/tech-docs-template | YES | Ruby based. <br><br> The original GDS sponsored effort to create a gov.uk compliant docs as code pattern. | https://ho-cto.github.io/sre-monitoring-as-code/ |
-| Eleventy and x-gov Eleventy plugin <br><br> https://www.11ty.dev/docs/ <br><br> https://x-govuk.github.io/posts/govuk-eleventy-plugin/ | YES | Node.js based. <br><br> A newer offering that also provides gov.uk styling and easy to configure search functionality. | https://ukhomeoffice.github.io/hocs/get-started/ |
+Links to documentation
+: - [Middleman](https://middlemanapp.com/)
+  - [Alpha-gov tech docs template](https://tdt-documentation.london.cloudapps.digital/)
+
+Reviewed
+: Yes
+
+Comments
+: Ruby based. 
+  
+  The original GDS sponsored effort to create a gov.uk compliant docs as code pattern.
+
+Example of Home Office documentation using this option
+: [SRE monitoring as code](https://ho-cto.github.io/sre-monitoring-as-code/)
+
+#### Eleventy and x-gov Eleventy plugin
+
+Links to documentation
+: - [Eleventy](https://www.11ty.dev/docs/)
+  - [X-gov eleventy plugin](https://x-govuk.github.io/posts/govuk-eleventy-plugin/)
+
+Reviewed
+: Yes
+
+Comments
+: Node.js based.
+  
+  A newer offering that also provides gov.uk styling and easy to configure search functionality.
+
+Example of Home Office documentation using this option
+: [DECS developer documentation](https://ukhomeoffice.github.io/hocs/get-started/)
 
 ---

--- a/lib/markdown/dl-as-govuk-summary-list.js
+++ b/lib/markdown/dl-as-govuk-summary-list.js
@@ -1,0 +1,23 @@
+/**
+ * This hooks into `markdown-it-deflist` and adds classes to render them using GovUK summary list styles.
+ *
+ * Note that as the summary list wraps the `dt` and `dd`s in `div.govuk-summary-list__row` and deflist doesn't have
+ * hooks for the start and end of a pair we need to track this ourselves with the rowOpened flag.
+ */
+module.exports = (md) => {
+  const {rules} = md.renderer
+  let rowOpened = false;
+
+  rules.dl_open = () => '<dl class="govuk-summary-list">\n'
+  rules.dt_open = () => {
+    const maybeCloseRowDiv = rowOpened ? '</div>' : '';
+    rowOpened = true;
+    return maybeCloseRowDiv + '<div class="govuk-summary-list__row"><dt class="govuk-summary-list__key">\n';
+  }
+  rules.dd_open = () => '<dt class="govuk-summary-list__value">\n'
+  rules.dl_close = () => {
+    const maybeCloseRowDiv = rowOpened ? '</div>' : '';
+    rowOpened = false;
+    return maybeCloseRowDiv + '</dl>'
+  }
+}


### PR DESCRIPTION
- Migrate docs-as-code pattern to use `dl`s for technical summaries of docs-as-code frameworks

Is this pull request a content or a code change? Code change with content presenntation change

# Code change
I can confirm:
## Accessibility considerations
- [X] This change might impact accessibility, automated aXe tests cover the impact

# Content change 
I can confirm:
- [X] ~Content does not include any code or configuration changes (excluding frontmatter information)~ The content semantics have not changed, but the presentation has been updated.
- [X] Content meets the content standards
e.g. [Writing a principle](https://ho-cto.github.io/engineering-guidance-and-standards/docs/standards/writing-a-principle/) and [Writing a standard](https://ho-cto.github.io/engineering-guidance-and-standards/docs/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
