### PR TITLE
Create 'Managing the security of software dependencies' standard

### DIFF
--- a/docs/standards/managing-dependencies.md
+++ b/docs/standards/managing-dependencies.md
@@ -1,0 +1,78 @@
+---
+layout: standard
+order: 1
+title: Managing dependencies
+date: 2023-08-28
+id: SEGAS-00007
+tags:
+  - Secure development
+  - Source management
+related:
+  sections:
+    - title: Related links
+      items:
+        - text: Well managed code
+          href: /principles/well-managed-code/
+        - text: Write maintainable, reusable and evolutionary code
+          href: /principles/write-maintainable-reusable-and-evolutionary-code/
+---
+<!-- Standard description -->
+
+The risk of poorly managed software dependencies remains significant across industries, as recognised by continuing [inclusion in the OWASP Top 10 application security risks](https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/).
+
+The [Log4Shell zero-day vulnerability in Log4j](https://www.ncsc.gov.uk/news/apache-log4j-vulnerability) is a recent example of how software dependencies can introduce credible and serious risk of exploitation of services.
+
+Home Office engineering teams are required to manage software dependencies proactively, to mitigate the risks of software supply chain attacks.
+
+<!-- 
+# Notes on using links
+
+Internal links need to follow this format:
+[link text to internal page]({{ '/standards/writing-a-standard/' | url }})
+Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
+
+External links follow standard markdown formatting:
+[link text to external page](https://example.com)
+-->
+
+---
+
+## Requirement(s)
+
+- [You MUST assess the security of external components before introducing them into software designs](#you-must-assess-the-security-of-external-components-before-introducing-them-into-software-designs)
+- [You MUST maintain a discoverable dependency tree for your systems](#you-must-maintain-a-discoverable-dependency-tree-for-your-systems)
+
+### You MUST assess the security of external components before introducing them into software designs
+
+You must understand how well developed and maintained your software components are. The [Open Source Security Foundation (OSSF) has a framework for assessing the security of open source projects](https://github.com/ossf/scorecard#scorecard-checks). You should use the [OSSF Scorecard](https://github.com/ossf/scorecard) as part of your assessment of open source dependencies, and use similar criteria to assess the security of other dependencies. Key questions to answer include:
+
+- Who maintains and supports that component?
+- Does that maintenance follow best practices for vulnerability identification, and are vulnerabilities rectified in a timely manner?
+- What protections are in place to prevent the incorporation of malicious code into that component?
+
+### You MUST maintain a discoverable dependency tree for your systems
+
+POMs and package.json are examples of files that include the specification of dependencies required to build a piece of software. However they do not always provide a full picture of the dependency tree of a built application, this because they do not always specify precisely which version of a dependency is to be used, and they do not always elaborate on nested dependencies.
+
+Engineers must be able to fully understand which dependencies are running or included in an application, and be able to tie artefacts to a precise dependency tree and versioned code. Teams should generate Software Bills of Materials (SBOMs) in the build process, and share them with operations teams, so that vulnerabilities in applications can be accurately identified and appropriately remediated.
+
+### You MUST use a scanning tool to identify dependencies with vulnerabilities
+
+Part of the pipeline at buildtime, as minimum. Also possible to do pre-commit scans with T
+Continuous scanning of what is running
+Also scan artefacts
+
+Scanning tools are good for identifying potential vulnerabilities in your dependencies. Teams must then triage those vulnerabilities to understand the applicability in their case, document the risks to the product and instigate the appropriate course of action to mitigate them.
+
+### You MUST be prepared to update, replace and remove dependencies
+
+Un-patchable systems are a recognised anti-pattern - https://www.ncsc.gov.uk/whitepaper/security-architecture-anti-patterns#section_8
+
+Reference deployment strategies
+You must test the compatibility 
+
+Using a package manager will help
+
+So will good software design - dependent on behaviour not the thing
+
+---

--- a/docs/standards/managing-dependencies.md
+++ b/docs/standards/managing-dependencies.md
@@ -50,7 +50,7 @@ Assessment of software components should take in to account nested or transitive
 
 ### You MUST maintain a discoverable dependency tree for your systems
 
-POMs and package.json are examples of files that include the specification of dependencies required to build a piece of software. However they do not always provide a full picture of the dependency tree of a built application, this because they do not always specify precisely which version of a dependency is to be used, and they do not always elaborate on nested dependencies.
+[POMs](https://maven.apache.org/guides/introduction/introduction-to-the-pom.html) and [package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json) are examples of files that include the specification of dependencies required to build a piece of software. However they do not always provide a full picture of the dependency tree of a built application, this because they do not always specify precisely which version of a dependency is to be used, and they do not always elaborate on nested dependencies.
 
 Engineers must be able to fully understand which dependencies are running or included in an application, and be able to tie built artefacts to a precise dependency tree and versioned code. Teams should generate Software Bills of Materials (SBOMs) in the build process, and share them with operations teams, so that vulnerabilities in applications can be accurately identified and appropriately remediated.
 

--- a/docs/standards/managing-dependencies.md
+++ b/docs/standards/managing-dependencies.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Managing dependencies
-date: 2023-08-28
+date: 2023-08-29
 id: SEGAS-00007
 tags:
   - Secure development

--- a/docs/standards/managing-dependencies.md
+++ b/docs/standards/managing-dependencies.md
@@ -72,7 +72,7 @@ Engineering teams must plan and perform updates to their software components. Th
 
 - [Select and define a deployment strategy]({{ '/patterns/selecting-a-deployment-strategy/' | url }}) that enables the promotion of patches and dependency changes into production frequently
 - Configure pipelines and test suites to allow testing for the compatibility of modified software components
-- Monitor and triage the ongoing need to patch, update or change the configuration of components, over the lifecylce of the product
+- Monitor and triage the ongoing need to patch, update or change the configuration of components, over the lifecycle of the product
 - Employ good software design principles to loosely couple external dependencies where possible, making it easier to replace them if required
 - Use package managers and software composition analysis tools to automate patch management and identify unnecessary dependencies that can be removed
 

--- a/docs/standards/managing-dependencies.md
+++ b/docs/standards/managing-dependencies.md
@@ -6,7 +6,12 @@ date: 2023-08-28
 id: SEGAS-00007
 tags:
   - Secure development
+  - Software design
+  - CI/CD
   - Source management
+  - Build, release and deploy
+  - Security
+  - Dependencies
 related:
   sections:
     - title: Related links
@@ -16,7 +21,6 @@ related:
         - text: Write maintainable, reusable and evolutionary code
           href: /principles/write-maintainable-reusable-and-evolutionary-code/
 ---
-<!-- Standard description -->
 
 The risk of poorly managed software dependencies remains significant across industries, as recognised by continuing [inclusion in the OWASP Top 10 application security risks](https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/).
 
@@ -24,23 +28,14 @@ The [Log4Shell zero-day vulnerability in Log4j](https://www.ncsc.gov.uk/news/apa
 
 Home Office engineering teams are required to manage software dependencies proactively, to mitigate the risks of software supply chain attacks.
 
-<!-- 
-# Notes on using links
-
-Internal links need to follow this format:
-[link text to internal page]({{ '/standards/writing-a-standard/' | url }})
-Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
-
-External links follow standard markdown formatting:
-[link text to external page](https://example.com)
--->
-
 ---
 
 ## Requirement(s)
 
 - [You MUST assess the security of external components before introducing them into software designs](#you-must-assess-the-security-of-external-components-before-introducing-them-into-software-designs)
 - [You MUST maintain a discoverable dependency tree for your systems](#you-must-maintain-a-discoverable-dependency-tree-for-your-systems)
+- [You MUST proactively identify vulnerabilities in dependencies with scanning and other tools](#you-must-proactively-identify-vulnerabilities-in-dependencies-with-scanning-and-other-tools)
+- [You MUST regularly update, replace and remove dependencies](#you-must-regularly-update-replace-and-remove-dependencies)
 
 ### You MUST assess the security of external components before introducing them into software designs
 
@@ -49,30 +44,36 @@ You must understand how well developed and maintained your software components a
 - Who maintains and supports that component?
 - Does that maintenance follow best practices for vulnerability identification, and are vulnerabilities rectified in a timely manner?
 - What protections are in place to prevent the incorporation of malicious code into that component?
+- Are you able to verify the integrity and provenance of components, to reduce the risk of including modified or malicious components?
+
+Assessment of software components should take in to account nested or transitive dependencies as well as direct dependencies.
 
 ### You MUST maintain a discoverable dependency tree for your systems
 
 POMs and package.json are examples of files that include the specification of dependencies required to build a piece of software. However they do not always provide a full picture of the dependency tree of a built application, this because they do not always specify precisely which version of a dependency is to be used, and they do not always elaborate on nested dependencies.
 
-Engineers must be able to fully understand which dependencies are running or included in an application, and be able to tie artefacts to a precise dependency tree and versioned code. Teams should generate Software Bills of Materials (SBOMs) in the build process, and share them with operations teams, so that vulnerabilities in applications can be accurately identified and appropriately remediated.
+Engineers must be able to fully understand which dependencies are running or included in an application, and be able to tie built artefacts to a precise dependency tree and versioned code. Teams should generate Software Bills of Materials (SBOMs) in the build process, and share them with operations teams, so that vulnerabilities in applications can be accurately identified and appropriately remediated.
 
-### You MUST use a scanning tool to identify dependencies with vulnerabilities
+### You MUST proactively identify vulnerabilities in dependencies with scanning and other tools
 
-Part of the pipeline at buildtime, as minimum. Also possible to do pre-commit scans with T
-Continuous scanning of what is running
-Also scan artefacts
+Teams must identify and then triage vulnerabilities in their code and dependencies, understand and document the risks to the product, and then instigate the appropriate course of action to mitigate them. Scanning tools assist with this by providing checks for known vulnerabilities, and can increase the automation of their mitigation, for example raising pull requests. However, teams should also subscribe to security bulletins for components when scanning tools do not provide sufficient coverage.
 
-Scanning tools are good for identifying potential vulnerabilities in your dependencies. Teams must then triage those vulnerabilities to understand the applicability in their case, document the risks to the product and instigate the appropriate course of action to mitigate them.
+Vulnerability scanning should be automated and implemented in multiple locations, as below. Platform teams and Home Office Cyber Security (HOCS) will advise on the appropriate tooling to use in each case.
 
-### You MUST be prepared to update, replace and remove dependencies
+- Source code scanning should be implemented on source code repositories, for example with Dependabot. This enables the identification of vulnerabilities during development, shifting remediation activities to the left
+- In pipelines. Vulnerability scanners like Trivy should be employed to check code and dependencies as they are built, and can also scan containers. This reduces the risk of vulnerabilities being built into artefacts and allows for pipelines to be failed on set criteria
+- Vulnerabilities can become known in applications that have previously been successfully built. Regular and continuous scanning of built artefacts allows teams to understand the risks to running systems in higher environments. Discoverable and accurate dependency trees assist with this
 
-Un-patchable systems are a recognised anti-pattern - https://www.ncsc.gov.uk/whitepaper/security-architecture-anti-patterns#section_8
+### You MUST regularly update, replace and remove dependencies
 
-Reference deployment strategies
-You must test the compatibility 
+[Vulnerable and outdated components remains an OWASP Top 10 application security risk](https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/). Un-patchable systems are a [recognised anti-pattern](https://www.ncsc.gov.uk/whitepaper/security-architecture-anti-patterns#section_8) that prevent or delay the mitigation of those security risks, and introduce further risks to the timely management of technical debt. Teams must be prepared to patch systems at short notice.
 
-Using a package manager will help
+Engineering teams must plan and perform updates to their software components. There are a number of things teams should do to enable this on an ongoing basis:
 
-So will good software design - dependent on behaviour not the thing
+- [Select and define a deployment strategy]({{ '/patterns/selecting-a-deployment-strategy/' | url }}) that enables the promotion of patches and dependency changes into production frequently
+- Configure pipelines and test suites to allow testing for the compatibility of modified software components
+- Monitor and triage the ongoing need to patch, update or change the configuration of components, over the lifecylce of the product
+- Employ good software design principles to loosely couple external dependencies where possible, making it easier to replace them if required
+- Use package managers and software composition analysis tools to automate patch management and identify unnecessary dependencies that can be removed
 
 ---

--- a/docs/standards/managing-security-software-dependencies.md
+++ b/docs/standards/managing-security-software-dependencies.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Managing the security of software dependencies
-date: 2023-08-29
+date: 2023-09-08
 id: SEGAS-00007
 tags:
   - Secure development

--- a/docs/standards/managing-security-software-dependencies.md
+++ b/docs/standards/managing-security-software-dependencies.md
@@ -1,7 +1,7 @@
 ---
 layout: standard
 order: 1
-title: Managing dependencies
+title: Managing the security of software dependencies
 date: 2023-08-29
 id: SEGAS-00007
 tags:


### PR DESCRIPTION
Will close #238 

# Content change 
I can confirm:
- [x] Content does not include any code or configuration changes (excluding frontmatter information)
- [x] Content meets the content standards
e.g. [Writing a principle](https://ho-cto.github.io/engineering-guidance-and-standards/docs/standards/writing-a-principle/) and [Writing a standard](https://ho-cto.github.io/engineering-guidance-and-standards/docs/standards/writing-a-standard/)
- [x] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [x] Last updated date for content is correct
