### PR TITLE
Update tag pages to match other content listing pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -80,10 +80,10 @@ module.exports = function(eleventyConfig) {
 
     // Used for tag page generation
     eleventyConfig.addFilter("getAllTags", collection => {
-        let tagSet = new Set();
-        for(let item of collection) {
-            (item.data.tags || []).forEach(tag => tagSet.add(tag));
-        }
+      let tagSet = new Set();
+      for(let item of collection) {
+          (item.data.tags || []).forEach(tag => tagSet.add(tag));
+      }
       return Array.from(tagSet).sort(function(a, b) {
         return a.localeCompare(b); // sort by tag name
       });

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -84,12 +84,20 @@ module.exports = function(eleventyConfig) {
         for(let item of collection) {
             (item.data.tags || []).forEach(tag => tagSet.add(tag));
         }
-        return Array.from(tagSet);
+      return Array.from(tagSet).sort(function(a, b) {
+        return a.localeCompare(b); // sort by tag name
+      });
     });
 
     eleventyConfig.addFilter("filterTagList", function filterTagList(tags) {
         // Tags in array are ignored, no tag list page is generated for these
         return (tags || []).filter(tag => ["homepage"].indexOf(tag) === -1);
+    });
+
+    eleventyConfig.addFilter("orderPagesByTitle", function orderByTitle(collection) {
+      return collection.sort(function(a, b) {
+        return a.data.title.localeCompare(b.data.title); // sort by title ascending
+      });
     });
 
     eleventyConfig.addCollection("homepageLinks", function(collectionApi) {
@@ -107,7 +115,7 @@ module.exports = function(eleventyConfig) {
 
     eleventyConfig.addCollection("getAllStandardsOrderedByTitle", function(collectionApi) {
       return collectionApi.getFilteredByGlob("**/standards/*.md").sort(function(a, b) {
-          return a.data.id.localeCompare(b.data.title); // sort by title ascending
+          return a.data.title.localeCompare(b.data.title); // sort by title ascending
         });
     });
 

--- a/_includes/layouts/tag.njk
+++ b/_includes/layouts/tag.njk
@@ -12,3 +12,29 @@
     {{ super() }}
   </nav>
 {% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ appDocumentHeader({
+      title: title or ("Posts tagged ‘" + tag + "’")
+    }) }}
+
+    {% import "macros/contentDocumentList.njk" as documentList %}
+    {{ documentList.contentDocumentList({
+      headingLevel: 3 if paginationHeading else 2,
+      classes: "app-document-list--large",
+      items: collections[tag] | orderPagesByTitle
+    }) }}
+
+    {{ appProseScope(content) if content }}
+
+  </div>
+  <div class="govuk-grid-column-one-third-from-desktop">
+    {% block sidebar %}
+      {% from "macros/navigationList.njk" import navigationList %}
+      {{ navigationList(page.url, "Engineering guidance and standards", collections.homepageLinks) }}
+    {% endblock %}
+  </div>
+</div>
+{% endblock %}

--- a/_includes/layouts/tags.njk
+++ b/_includes/layouts/tags.njk
@@ -12,3 +12,36 @@
     {{ super() }}
   </nav>
 {% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ appDocumentHeader({
+        title: title or "Tags"
+      }) }}
+
+      <ul class="govuk-list govuk-list--bullet">
+       {% for tag in collections.all | getAllTags | filterTagList %}
+        {% if tag == "Patterns" %}
+          {%- set tagUrl %}{{ "/patterns/" | url }}/{% endset %}
+        {% elseif tag == "Principles" %}
+          {%- set tagUrl %}{{ "/principles/" | url }}/{% endset %}
+        {% elseif tag == "Standards" %}
+         {%- set tagUrl %}{{ "/standards" | url }}/{% endset %}
+        {% else %}
+         {%- set tagUrl %}{{ "/tags/" | url }}{{ tag | slugify }}/{% endset %}
+        {% endif %}
+        <li>
+          <a href="{{ tagUrl }}">{{ tag }}</a>
+        </li>
+       {% endfor %}
+      </ul>
+    </div>
+    <div class="govuk-grid-column-one-third-from-desktop">
+      {% block sidebar %}
+        {% from "macros/navigationList.njk" import navigationList %}
+        {{ navigationList(page.url, "Engineering guidance and standards", collections.homepageLinks) }}
+      {% endblock %}
+    </div>
+  </div>
+{% endblock %}

--- a/cypress/e2e/a11y.spec.cy.js
+++ b/cypress/e2e/a11y.spec.cy.js
@@ -33,3 +33,24 @@ describe('All pages pass axe-core accessibility checks', () => {
     })
   }
 })
+
+describe('Tag pages pass axe-core accessibility checks', () => {
+  it('Tag page is accessible', () => {
+    cy.visit(testing_params.TEST_ROOT_URL)
+    cy.contains('Read our standards').click()
+    cy.contains('Minimal documentation set for a product').click()
+    cy.get('.tags').contains('Documentation').click()
+    cy.injectAxe()
+    cy.checkA11y({exclude: '[data-axe-exclude]'}, null, terminalLog);
+  })
+
+  it('All tags is accessible', () => {
+    cy.visit(testing_params.TEST_ROOT_URL)
+    cy.contains('Read our standards').click()
+    cy.contains('Minimal documentation set for a product').click()
+    cy.get('.tags').contains('Documentation').click()
+    cy.contains('all tags').click()
+    cy.injectAxe()
+    cy.checkA11y({exclude: '[data-axe-exclude]'}, null, terminalLog);
+  })
+})

--- a/docs/tags-list.md
+++ b/docs/tags-list.md
@@ -3,19 +3,7 @@
 eleventyExcludeFromCollections: true
 title: All page tags currently in use
 permalink: /tags/
-layout: sub-navigation
+layout: tags
 ---
 
-{% for tag in collections.all | getAllTags | filterTagList %}
-{%- set tagUrl %}{{ "/tags/" | url }}{{ tag | slugify }}/{% endset %}
-  {% if tag == "Patterns" %}
-  - [{{tag}}]({{"/patterns" | url}})
-  {% elseif tag == "Principles" %}
-  - [{{tag}}]({{"/principles" | url}})
-  {% elseif tag == "Standards" %}
-  - [{{tag}}]({{"/standards" | url}})
-  {% else %}
-  - [{{tag}}]({{ tagUrl }})
-  {% endif %}
-{% endfor %}
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,6 +1,6 @@
 ---
 eleventyExcludeFromCollections: true
-layout: sub-navigation
+layout: tag
 pagination:
   data: collections
   # removes (page 1 of n) from title (where n is total number of tags in use)
@@ -21,10 +21,5 @@ eleventyComputed:
   title: Pages tagged with "{{ tag }}"
 permalink: /tags/{{ tag | slugify }}/
 ---
-
-{% set postsWithTag = collections[ tag ] %}
-{% for post in postsWithTag | reverse %}
-- [{{post.data.title}}]({{post.url | url}})
-{% endfor %}
 
 See [all tags]({{"/tags/" | url}})


### PR DESCRIPTION
- Using tag/tags layouts for tags page and all tags page, respectively.
- Updated layouts to use standard content listing and to display three main content links (to match other pages)

Is this pull request a content or a code change? (Please fill in the relevant section and delete the other)

# Code change
I can confirm:
## Accessibility considerations
- [x] This change might impact accessibility, automated aXe tests cover the impact
