### PR TITLE
Removed related links from standards page

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -117,11 +117,12 @@ describe('Cookies page links from footer test', () => {
 describe('Related links respect path prefix', () => {
   it('finds the related writing a standard link and follows it to a valid page', () => {
     cy.visit(testing_params.TEST_ROOT_URL)
-    // Click to standards page that has a related link
+    // Click through to standard page that has a related link
     cy.contains('Read our standards').click()
+    cy.contains('Infrastructure utilisation monitoring').click()
     // Use the related link
-    cy.contains('.x-govuk-related-navigation a', 'Writing a standard').click()
-    cy.contains('h1', 'Writing a standard')
+    cy.contains('.x-govuk-related-navigation a', 'Monitor and measure proactively').click()
+    cy.contains('h1', 'Monitor and measure proactively')
   })
 })
 

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -115,7 +115,7 @@ describe('Cookies page links from footer test', () => {
 })
 
 describe('Related links respect path prefix', () => {
-  it('finds the related writing a standard link and follows it to a valid page', () => {
+  it('finds the correct related link and follows it to a valid page', () => {
     cy.visit(testing_params.TEST_ROOT_URL)
     // Click through to standard page that has a related link
     cy.contains('Read our standards').click()

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -8,10 +8,4 @@ paginationHeading: false
 pagination:
   data: collections.getAllStandardsOrderedByTitle
   size: 10
-related:
-  sections:
-    - title: Related links
-      items:
-        - text: Writing a standard
-          href: /standards/writing-a-standard/ # https://github.com/11ty/eleventy-dev-server/pull/64
 ---


### PR DESCRIPTION
Removed related link from standards page.
Intent is to reinstate when site is migrated to ACP and we do not have issues with usage of `pathPrefix`

# Code change
I can confirm:
## Accessibility considerations
- [x] This change will not change layouts, page structures or anything else that might impact accessibility
